### PR TITLE
Update bot version from 0.0.1 to 1.0.0 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ $(dar): $(target_dir) $(daml_build_log)
 	cp .daml/dist/chess-$(dar_version).dar $@
 
 $(bot): $(target_dir) $(operator_bot_dir)
-	cp operator_bot/dist/bot-0.0.1.tar.gz $@
+	cp operator_bot/dist/bot-1.0.0.tar.gz $@
 
 $(ui): $(target_dir) $(yarn_build_log)
 	cd ui && yarn build


### PR DESCRIPTION
I noticed when running `make package` that the build fails when copying the bot tarball due to the wrong version in the filename. This is a simple typo fix.